### PR TITLE
Add the zero-indexed SNP Index to IHS and XPEHH output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ The map files (`--map`) should be in the same format as used by [Selscan](https:
 ### Output file formats ###
 
 - ehhbin outputs five columns. The first three being the locus' ID and its genetic and physical positions. These are followed by two columns corresponding to the EHH for each of the alleles at this locus (allele coded as 0 then 1).
-- ihsbin outputs a file with each allele's iHH value (iHH_0 and iHH_1) as well as the unstandardised and standardised iHS values (alleles grouped in to 2% frequency bins for standardisation by default). The first column is the SNP locus id (as specified in the map file).
-- xpehh outputs a file containing five columns: the SNP locus id (as specified in the map file), corresponding iHH values and finally the XP-EHH value.
+- ihsbin outputs a file with each allele's iHH value (iHH_0 and iHH_1) as well as the unstandardised and standardised iHS values (alleles grouped in to 2% frequency bins for standardisation by default). The first column is the zero-indexed location of the SNP in the hap and map files. The second column is the SNP's locus id (as specified in the map file).
+- xpehh outputs a file containing six columns: the zero-indexed location, the SNP locus id (as specified in the map file), corresponding iHH values, and finally the XP-EHH value.
 
 ### Examples ###
 

--- a/src/ihs.cpp
+++ b/src/ihs.cpp
@@ -61,12 +61,12 @@ void calcIhsNoMpi(
     auto unStd = ihsfinder->unStdIHSByLine();
 
     std::ofstream out2(outfile);
-    out2 << "Location\tFreq\tiHH_0\tiHH_1\tiHS\tStd iHS" << std::endl;
+    out2 << "Index\tID\tFreq\tiHH_0\tiHH_1\tiHS\tStd iHS" << std::endl;
 
     for (const auto& it : res)
     {
         auto s = unStd[it.first];
-        out2 << hm.lineToId(it.first) << '\t' << s.freq << '\t' << s.iHH_0 << '\t' << s.iHH_1 << '\t' << s.iHS << "\t" << it.second << std::endl;
+        out2 << it.first << '\t' << hm.lineToId(it.first) << '\t' << s.freq << '\t' << s.iHH_0 << '\t' << s.iHH_1 << '\t' << s.iHS << "\t" << it.second << std::endl;
     }
     std::cout << "# valid loci: " << res.size() << std::endl;
     std::cout << "# loci with MAF <= " << minMAF << ": " << ihsfinder->numOutsideMaf() << std::endl;

--- a/src/ihs_mpi.cpp
+++ b/src/ihs_mpi.cpp
@@ -160,12 +160,12 @@ void calcIhsMpi(
             out << hap.lineToId(it.first) << '\t' << it.second.iHH_0 << '\t' << it.second.iHH_1 << '\t' << it.second.iHS << std::endl;
         }*/
         std::ofstream out2(outfile);
-        out2 << "Location\tFreq\tiHH_0\tiHH_1\tiHS\tStd iHS" << std::endl;
+        out2 << "Index\tID\tFreq\tiHH_0\tiHH_1\tiHS\tStd iHS" << std::endl;
 
         for (const auto& it : res)
         {
             auto s = unStd[it.first];
-            out2 << hap.lineToId(it.first) << '\t' << s.freq << '\t' << s.iHH_0 << '\t' << s.iHH_1 << '\t' << s.iHS << "\t" << it.second << std::endl;
+            out2 << it.first << '\t' << hap.lineToId(it.first) << '\t' << s.freq << '\t' << s.iHH_0 << '\t' << s.iHH_1 << '\t' << s.iHS << "\t" << it.second << std::endl;
         }
         std::cout << "# valid loci: " << res.size() << std::endl;
         std::cout << "# loci with MAF <= " << minMAF << ": " << ihsfinder->numOutsideMaf() << std::endl;

--- a/src/xpehh.cpp
+++ b/src/xpehh.cpp
@@ -66,11 +66,11 @@ void calcXpehhNoMpi(
     std::cout << "Calculations took " << std::chrono::duration<double, std::milli>(diff).count() << "ms" << std::endl;
 
     std::ofstream out(outfile);
-    out << "Location\tFreq\tiHH_A1\tiHH_B1\tiHH_P1\tXPEHH\tstd XPEHH" << std::endl;
+    out << "Index\tID\tFreq\tiHH_A1\tiHH_B1\tiHH_P1\tXPEHH\tstd XPEHH" << std::endl;
     for (const auto& it : ihsfinder->unStdXPEHHByLine())
     {
         double freq = (double)(it.second.numA + it.second.numB)/((double) hA.snpLength() + hB.snpLength());
-        out << hA.lineToId(it.first) << '\t' << freq << '\t' << it.second.iHH_A1 << '\t' << it.second.iHH_B1 << '\t' << it.second.iHH_P1 << '\t' << it.second.xpehh << '\t' << standardized[it.first] << std::endl;
+        out << it.first << '\t' << hA.lineToId(it.first) << '\t' << freq << '\t' << it.second.iHH_A1 << '\t' << it.second.iHH_B1 << '\t' << it.second.iHH_P1 << '\t' << it.second.xpehh << '\t' << standardized[it.first] << std::endl;
     }
 
     std::cout << "# valid loci: " << minMAF << ": " << ihsfinder->unStdXPEHHByLine().size() << std::endl;

--- a/src/xpehh_mpi.cpp
+++ b/src/xpehh_mpi.cpp
@@ -158,11 +158,11 @@ void calcXpehhMpi(
         std::cout << "Calculations took " << std::chrono::duration<double, std::milli>(diff).count() << "ms" << std::endl;
 
         std::ofstream out(outfile);
-        out << "Location\tFreq\tiHH_A1\tiHH_B1\tiHH_P1\tXPEHH\tstd XPEHH" << std::endl;
+        out << "Index\tID\tFreq\tiHH_A1\tiHH_B1\tiHH_P1\tXPEHH\tstd XPEHH" << std::endl;
         for (const auto& it : ihsfinder->unStdXPEHHByLine())
         {
             double freq = (double)(it.second.numA + it.second.numB)/((double) mA.snpLength() + mB.snpLength());
-            out << mA.lineToId(it.first) << '\t' << freq << '\t' << it.second.iHH_A1 << '\t' << it.second.iHH_B1 << '\t' << it.second.iHH_P1 << '\t' << it.second.xpehh << '\t' << standardized[it.first] << std::endl;
+            out << it.first << '\t' << mA.lineToId(it.first) << '\t' << freq << '\t' << it.second.iHH_A1 << '\t' << it.second.iHH_B1 << '\t' << it.second.iHH_P1 << '\t' << it.second.xpehh << '\t' << standardized[it.first] << std::endl;
         }
         std::cout << "# valid loci: " << ihsfinder->unStdXPEHHByLine().size() << std::endl;
     }


### PR DESCRIPTION
Allow easy lookup of data in the map files by providing the zero-indexed line location of the snp. See bug #49.